### PR TITLE
Added tls cipher suite to avoid tls errors

### DIFF
--- a/inv/group_vars/srl.yml
+++ b/inv/group_vars/srl.yml
@@ -4,6 +4,7 @@ ansible_user: admin
 ansible_password: NokiaSrl1!
 ansible_httpapi_use_ssl: true
 ansible_httpapi_validate_certs: false
+ansible_httpapi_ciphers: ECDHE-RSA-AES256-SHA
 ansible_become: no
 platform: srlinux
 
@@ -13,4 +14,3 @@ system:
   information:
     location: SomeWhere
     contact: SomeOne
-


### PR DESCRIPTION
@wdesmedt due to this https://learn.srlinux.dev/ansible/collection/#tls-13-support-and-cipher-suites we need to set the cipher suite to avoid errors on recent py version:

```
TASK [common/init : Get facts from device] ***********************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.module_utils.connection.ConnectionError: Could not connect to https://172.20.21.102:443/jsonrpc: [SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:997)
```